### PR TITLE
Add bazel test to ensure the in-tree year bundles match generation script output

### DIFF
--- a/2024.json
+++ b/2024.json
@@ -1,138 +1,98 @@
 [
   {
-    "path": "2024/Phoenix6-24.1.0.json",
-    "name": "CTRE-Phoenix (v6)",
-    "version": "24.1.0",
-    "uuid": "e995de00-2c64-4df5-8831-c1441420ff19",
-    "description": "CTR-Electronics Phoenix 6 framework",
-    "website": "https://v6.docs.ctr-electronics.com/en/latest/index.html"
-  },
-  {
-    "path": "2024/Phoenix6-24.2.0.json",
-    "name": "CTRE-Phoenix (v6)",
-    "version": "24.2.0",
-    "uuid": "e995de00-2c64-4df5-8831-c1441420ff19",
-    "description": "CTR-Electronics Phoenix 6 framework",
-    "website": "https://v6.docs.ctr-electronics.com/en/latest/index.html"
-  },
-  {
-      "path": "2024/Phoenix6-24.3.0.json",
-      "name": "CTRE-Phoenix (v6)",
-      "version": "24.3.0",
-      "uuid": "e995de00-2c64-4df5-8831-c1441420ff19",
-      "description": "CTR-Electronics Phoenix 6 framework",
-      "website": "https://v6.docs.ctr-electronics.com/en/latest/index.html"
-  },
-  {
-    "path": "2024/Phoenix5-5.33.0.json",
-    "name": "CTRE-Phoenix (v5)",
-    "version": "5.33.0",
-    "uuid": "ab676553-b602-441f-a38d-f1296eff6537",
-    "description": "CTR-Electronics Phoenix 5 framework",
-    "website": "https://v5.docs.ctr-electronics.com/en/latest/index.html"
-  },
-  {
-    "path": "2024/Phoenix5-5.33.1.json",
-    "name": "CTRE-Phoenix (v5)",
-    "version": "5.33.1",
-    "uuid": "ab676553-b602-441f-a38d-f1296eff6537",
-    "description": "CTR-Electronics Phoenix 5 framework",
-    "website": "https://v5.docs.ctr-electronics.com/en/latest/index.html"
-  },
-  {
-    "path": "2024/REVLib-2024.2.0.json",
-    "name": "REVLib",
-    "version": "2024.2.0",
-    "uuid": "3f48eb8c-50fe-43a6-9cb7-44c86353c4cb",
-    "description": "REV Robotics REVLib C++/Java",
-    "website": "https://docs.revrobotics.com/brushless/spark-max/revlib"
-  },
-  {
-    "path": "2024/REVLib-2024.2.1.json",
-    "name": "REVLib",
-    "version": "2024.2.1",
-    "uuid": "3f48eb8c-50fe-43a6-9cb7-44c86353c4cb",
-    "description": "REV Robotics REVLib C++/Java",
-    "website": "https://docs.revrobotics.com/brushless/spark-max/revlib"
-  },
-  {
-    "path": "2024/REVLib-2024.2.2.json",
-    "name": "REVLib",
-    "version": "2024.2.2",
-    "uuid": "3f48eb8c-50fe-43a6-9cb7-44c86353c4cb",
-    "description": "REV Robotics REVLib C++/Java",
-    "website": "https://docs.revrobotics.com/brushless/spark-max/revlib"
-  },
-  {
-    "path": "2024/REVLib-2024.2.3.json",
-    "name": "REVLib",
-    "version": "2024.2.3",
-    "uuid": "3f48eb8c-50fe-43a6-9cb7-44c86353c4cb",
-    "description": "REV Robotics REVLib C++/Java",
-    "website": "https://docs.revrobotics.com/brushless/spark-max/revlib"
-  },
-  {
-    "path": "2024/REVLib-2024.2.4.json",
-    "name": "REVLib",
-    "version": "2024.2.4",
-    "uuid": "3f48eb8c-50fe-43a6-9cb7-44c86353c4cb",
-    "description": "REV Robotics REVLib C++/Java",
-    "website": "https://docs.revrobotics.com/brushless/spark-max/revlib"
-  },
-  {
-    "path": "2024/ChoreoLib-2024.2.2.json",
-    "name": "ChoreoLib",
-    "version": "2024.2.2",
-    "uuid": "287cff6e-1b60-4412-8059-f6834fb30e30",
-    "description": "A graphical tool for planning time-optimized trajectories for autonomous mobile robots in the FIRST Robotics Competition.",
-    "website": "https://github.com/SleipnirGroup/Choreo"
-  },
-  {
-    "path": "2024/NavX-2024.1.0.json",
-    "name": "NavX",
-    "version": "2024.1.0",
-    "uuid": "cb311d09-36e9-4143-a032-55bb2b94443b",
-    "description": "navX2-MXP includes software which makes navX2-MXP easier to understand, integrate and use with FIRST FRC and FTC robots",
-    "website": "https://pdocs.kauailabs.com/navx-mxp/software/roborio-libraries/"
-  },
-  {
-    "path": "2024/PathplannerLib-2024.2.8.json",
-    "name": "PathplannerLib",
-    "version": "2024.2.8",
-    "uuid": "1b42324f-17c6-4875-8e77-1c312bc8c786",
-    "description": "PathPlanner is a motion profile generator for FRC robots created by team 3015.",
-    "website": "https://pathplanner.dev/home.html"
-  },
-  {
-    "path": "2024/photonlib-v2024.3.1.json",
-    "name": "PhotonLib",
-    "version": "v2024.3.1",
     "uuid": "515fe07e-bfc6-11fa-b3de-0242ac130004",
+    "name": "PhotonLib",
     "description": "PhotonVision is the free, fast, and easy-to-use vision processing solution for the FIRST Robotics Competition.",
-    "website": "https://docs.photonvision.org/en/latest/docs/programming/photonlib/adding-vendordep.html"
+    "website": "https://docs.photonvision.org/en/latest/docs/programming/photonlib/adding-vendordep.html",
+    "path": "2024/photonlib-v2024.3.1.json",
+    "version": "v2024.3.1"
   },
   {
-    "path": "2024/playingwithfusion-2024.03.09.json",
-    "name": "playingwithfusion",
-    "version": "2024.03.09",
-    "uuid": "14b8ad04-24df-11ea-978f-2e728ce88125",
-    "description": "This library supports the Venom motor/controller as well as the CAN enabled Time of Flight sensor.",
-    "website": "https://www.playingwithfusion.com/docview.php?docid=1205"
+    "uuid": "3f48eb8c-50fe-43a6-9cb7-44c86353c4cb",
+    "name": "REVLib",
+    "description": "REV Robotics REVLib C++/Java",
+    "website": "https://docs.revrobotics.com/brushless/spark-max/revlib",
+    "path": "2024/REVLib-2024.2.1.json",
+    "version": "2024.2.1"
   },
   {
-    "path": "2024/ReduxLib-2024.1.1.json",
-    "name": "ReduxLib",
-    "version": "2024.1.1",
-    "uuid": "151ecca8-670b-4026-8160-cdd2679ef2bd",
-    "description": "To make performant and open products at affordable costs to teams.",
-    "website": "https://docs.reduxrobotics.com/reduxlib"
+    "uuid": "3f48eb8c-50fe-43a6-9cb7-44c86353c4cb",
+    "name": "REVLib",
+    "description": "REV Robotics REVLib C++/Java",
+    "website": "https://docs.revrobotics.com/brushless/spark-max/revlib",
+    "path": "2024/REVLib-2024.2.0.json",
+    "version": "2024.2.0"
   },
   {
-    "path": "2024/yagsl-2024.4.8.6.json",
-    "name": "yagsl",
-    "version": "2024.4.8.6",
-    "uuid": "1ccce5a4-acd2-4d18-bca3-4b8047188400",
-    "description": "YAGSL is a Swerve Library Developed by current and former BroncBotz mentors for all FRC Teams.",
-    "website": "https://yagsl.gitbook.io/yagsl"
+    "uuid": "1b42324f-17c6-4875-8e77-1c312bc8c786",
+    "name": "PathplannerLib",
+    "description": "PathPlanner is a motion profile generator for FRC robots created by team 3015.",
+    "website": "https://pathplanner.dev/home.html",
+    "path": "2024/PathplannerLib-2024.2.8.json",
+    "version": "2024.2.8"
+  },
+  {
+    "uuid": "e995de00-2c64-4df5-8831-c1441420ff19",
+    "name": "CTRE-Phoenix (v6)",
+    "description": "CTR-Electronics Phoenix 6 framework",
+    "website": "https://v6.docs.ctr-electronics.com/en/latest/index.html",
+    "path": "2024/Phoenix6-24.2.0.json",
+    "version": "24.2.0"
+  },
+  {
+    "uuid": "e995de00-2c64-4df5-8831-c1441420ff19",
+    "name": "CTRE-Phoenix (v6)",
+    "description": "CTR-Electronics Phoenix 6 framework",
+    "website": "https://v6.docs.ctr-electronics.com/en/latest/index.html",
+    "path": "2024/Phoenix6-24.3.0.json",
+    "version": "24.3.0"
+  },
+  {
+    "uuid": "ab676553-b602-441f-a38d-f1296eff6537",
+    "name": "CTRE-Phoenix (v5)",
+    "description": "CTR-Electronics Phoenix 5 framework",
+    "website": "https://v5.docs.ctr-electronics.com/en/latest/index.html",
+    "path": "2024/Phoenix5-5.33.1.json",
+    "version": "5.33.1"
+  },
+  {
+    "uuid": "ab676553-b602-441f-a38d-f1296eff6537",
+    "name": "CTRE-Phoenix (v5)",
+    "description": "CTR-Electronics Phoenix 5 framework",
+    "website": "https://v5.docs.ctr-electronics.com/en/latest/index.html",
+    "path": "2024/Phoenix5-5.33.0.json",
+    "version": "5.33.0"
+  },
+  {
+    "uuid": "3f48eb8c-50fe-43a6-9cb7-44c86353c4cb",
+    "name": "REVLib",
+    "description": "REV Robotics REVLib C++/Java",
+    "website": "https://docs.revrobotics.com/brushless/spark-max/revlib",
+    "path": "2024/REVLib-2024.2.3.json",
+    "version": "2024.2.3"
+  },
+  {
+    "uuid": "e995de00-2c64-4df5-8831-c1441420ff19",
+    "name": "CTRE-Phoenix (v6)",
+    "description": "CTR-Electronics Phoenix 6 framework",
+    "website": "https://v6.docs.ctr-electronics.com/en/latest/index.html",
+    "path": "2024/Phoenix6-24.1.0.json",
+    "version": "24.1.0"
+  },
+  {
+    "uuid": "3f48eb8c-50fe-43a6-9cb7-44c86353c4cb",
+    "name": "REVLib",
+    "description": "REV Robotics REVLib C++/Java",
+    "website": "https://docs.revrobotics.com/brushless/spark-max/revlib",
+    "path": "2024/REVLib-2024.2.4.json",
+    "version": "2024.2.4"
+  },
+  {
+    "uuid": "3f48eb8c-50fe-43a6-9cb7-44c86353c4cb",
+    "name": "REVLib",
+    "description": "REV Robotics REVLib C++/Java",
+    "website": "https://docs.revrobotics.com/brushless/spark-max/revlib",
+    "path": "2024/REVLib-2024.2.2.json",
+    "version": "2024.2.2"
   }
 ]

--- a/2025beta.json
+++ b/2025beta.json
@@ -1,226 +1,226 @@
 [
   {
+    "uuid": "cb311d09-36e9-4143-a032-55bb2b94443b",
+    "name": "Studica",
+    "description": "Libraries for NavX and other Studica Products",
+    "website": "https://github.com/Studica-Robotics/NavX/",
     "path": "2025beta/NavX-2025.1.1-beta-1.json",
-    "name": "Studica",
-    "version": "2025.1.1-beta-1",
-    "uuid": "cb311d09-36e9-4143-a032-55bb2b94443b",
-    "description": "Libraries for NavX-MXP and NavX-Micro",
-    "website": "https://pdocs.kauailabs.com/navx-mxp/software/roborio-libraries/"
+    "version": "2025.1.1-beta-1"
   },
   {
+    "uuid": "cb311d09-36e9-4143-a032-55bb2b94443b",
+    "name": "Studica",
+    "description": "Libraries for NavX and other Studica Products",
+    "website": "https://github.com/Studica-Robotics/NavX/",
     "path": "2025beta/Studica-2025.1.1-beta-2.json",
-    "name": "Studica",
-    "version": "2025.1.1-beta-2",
-    "uuid": "cb311d09-36e9-4143-a032-55bb2b94443b",
-    "description": "Libraries for NavX and other Studica Products",
-    "website": "https://github.com/Studica-Robotics/NavX"
+    "version": "2025.1.1-beta-2"
   },
   {
-    "path": "2025beta/Studica-2025.1.1-beta-3.json",
-    "name": "Studica",
-    "version": "2025.1.1-beta-3",
-    "uuid": "cb311d09-36e9-4143-a032-55bb2b94443b",
-    "description": "Libraries for NavX and other Studica Products",
-    "website": "https://github.com/Studica-Robotics/NavX"
-  },
-  {
-    "path": "2025beta/Studica-2025.1.1-beta-4.json",
-    "name": "Studica",
-    "version": "2025.1.1-beta-4",
-    "uuid": "cb311d09-36e9-4143-a032-55bb2b94443b",
-    "description": "Libraries for NavX and other Studica Products",
-    "website": "https://github.com/Studica-Robotics/NavX"
-  },
-  {
-    "path": "2025beta/Phoenix6-25.0.0-beta-1.json",
-    "name": "CTRE-Phoenix (v6)",
-    "version": "25.0.0-beta-1",
-    "uuid": "e995de00-2c64-4df5-8831-c1441420ff19",
-    "description": "Libraries for Phoenix 6 devices",
-    "website": "https://docs.ctr-electronics.com/"
-  },
-  {
-    "path": "2025beta/Phoenix6-25.0.0-beta-2.json",
-    "name": "CTRE-Phoenix (v6)",
-    "version": "25.0.0-beta-2",
-    "uuid": "e995de00-2c64-4df5-8831-c1441420ff19",
-    "description": "Libraries for Phoenix 6 devices",
-    "website": "https://docs.ctr-electronics.com/"
-  },
-  {
-    "path": "2025beta/Phoenix6-25.0.0-beta-3.json",
-    "name": "CTRE-Phoenix (v6)",
-    "version": "25.0.0-beta-3",
-    "uuid": "e995de00-2c64-4df5-8831-c1441420ff19",
-    "description": "Libraries for Phoenix 6 devices",
-    "website": "https://docs.ctr-electronics.com/"
-  },
-  {
-    "path": "2025beta/Phoenix6-replay-25.0.0-beta-1.json",
-    "name": "CTRE-Phoenix Replay (v6)",
-    "version": "25.0.0-beta-1",
-    "uuid": "e7900d8d-826f-4dca-a1ff-182f658e98af",
-    "description": "Libraries for Phoenix 6 devices with Hoot Replay",
-    "website": "https://docs.ctr-electronics.com/"
-  },
-  {
-    "path": "2025beta/Phoenix6-replay-25.0.0-beta-2.json",
-    "name": "CTRE-Phoenix Replay (v6)",
-    "version": "25.0.0-beta-2",
-    "uuid": "e7900d8d-826f-4dca-a1ff-182f658e98af",
-    "description": "Libraries for Phoenix 6 devices with Hoot Replay",
-    "website": "https://docs.ctr-electronics.com/"
-  },
-  {
-    "path": "2025beta/Phoenix6-replay-25.0.0-beta-3.json",
-    "name": "CTRE-Phoenix Replay (v6)",
-    "version": "25.0.0-beta-3",
-    "uuid": "e7900d8d-826f-4dca-a1ff-182f658e98af",
-    "description": "Libraries for Phoenix 6 devices with Hoot Replay",
-    "website": "https://docs.ctr-electronics.com/"
-  },
-  {
-    "path": "2025beta/Phoenix5-5.34.0-beta-1.json",
-    "name": "CTRE-Phoenix (v5)",
-    "version": "5.34.0-beta-1",
-    "uuid": "ab676553-b602-441f-a38d-f1296eff6537",
-    "description": "Libraries for Phoenix 5 devices",
-    "website": "https://docs.ctr-electronics.com/"
-  },
-  {
-    "path": "2025beta/Phoenix5-5.34.0-beta-2.json",
-    "name": "CTRE-Phoenix (v5)",
-    "version": "5.34.0-beta-2",
-    "uuid": "ab676553-b602-441f-a38d-f1296eff6537",
-    "description": "Libraries for Phoenix 5 devices",
-    "website": "https://docs.ctr-electronics.com/"
-  },
-  {
-    "path": "2025beta/Phoenix5-5.34.0-beta-3.json",
-    "name": "CTRE-Phoenix (v5)",
-    "version": "5.34.0-beta-3",
-    "uuid": "ab676553-b602-441f-a38d-f1296eff6537",
-    "description": "Libraries for Phoenix 5 devices",
-    "website": "https://docs.ctr-electronics.com/"
-  },
-  {
-    "path": "2025beta/PathplannerLib-2025.0.0-beta-3.json",
-    "name": "PathplannerLib",
-    "version": "2025.0.0-beta-3",
-    "uuid": "1b42324f-17c6-4875-8e77-1c312bc8c786",
-    "description": "PathPlanner's powerful robot-side vendor library",
-    "website": "https://pathplanner.dev/pathplannerlib.html"
-  },
-  {
-    "path": "2025beta/PathplannerLib-2025.0.0-beta-3.1.json",
-    "name": "PathplannerLib",
-    "version": "2025.0.0-beta-3.1",
-    "uuid": "1b42324f-17c6-4875-8e77-1c312bc8c786",
-    "description": "PathPlanner's powerful robot-side vendor library",
-    "website": "https://pathplanner.dev/pathplannerlib.html"
-  },
-  {
-    "path": "2025beta/PathplannerLib-2025.0.0-beta-4.json",
-    "name": "PathplannerLib",
-    "version": "2025.0.0-beta-4",
-    "uuid": "1b42324f-17c6-4875-8e77-1c312bc8c786",
-    "description": "PathPlanner's powerful robot-side vendor library",
-    "website": "https://pathplanner.dev/pathplannerlib.html"
-  },
-  {
-    "path": "2025beta/DogLog-2025.0.0.json",
-    "name": "DogLog",
-    "version": "2025.0.0",
-    "uuid": "65592ce1-2251-4a31-8e4b-2df20dacebe4",
-    "description": "Simpler logging for FRC",
-    "website": "https://doglog.dev/"
-  },
-  {
-    "path": "2025beta/REVLib-2025.0.0-beta-1.json",
-    "name": "REVLib",
-    "version": "2025.0.0-beta-1",
-    "uuid": "3f48eb8c-50fe-43a6-9cb7-44c86353c4cb",
-    "description": "Library for all REV devices including SPARK Flex, SPARK MAX, and Color Sensor V3",
-    "website": "https://docs.revrobotics.com/brushless/revlib/revlib-overview"
-  },
-  {
-    "path": "2025beta/REVLib-2025.0.0-beta-2.json",
-    "name": "REVLib",
-    "version": "2025.0.0-beta-2",
-    "uuid": "3f48eb8c-50fe-43a6-9cb7-44c86353c4cb",
-    "description": "Library for all REV devices including SPARK Flex, SPARK MAX, and Color Sensor V3",
-    "website": "https://docs.revrobotics.com/brushless/revlib/revlib-overview"
-  },
-  {
-    "path": "2025beta/REVLib-2025.0.0-beta-3.json",
-    "name": "REVLib",
-    "version": "2025.0.0-beta-3",
-    "uuid": "3f48eb8c-50fe-43a6-9cb7-44c86353c4cb",
-    "description": "Library for all REV devices including SPARK Flex, SPARK MAX, and Color Sensor V3",
-    "website": "https://docs.revrobotics.com/brushless/revlib/revlib-overview"
-  },
-  {
-    "path": "2025beta/URCL-2025.0.0-beta-1.json",
-    "name": "URCL",
-    "version": "2025.0.0-beta-1",
-    "uuid": "84246d17-a797-4d1e-bd9f-c59cd8d2477c",
-    "description": "Unofficial REV-Compatible Logger for AdvantageScope",
-    "website": "https://docs.advantagescope.org/more-features/urcl"
-  },
-  {
-    "path": "2025beta/ReduxLib_2025.json",
-    "name": "ReduxLib",
-    "version": "2025.0.0-beta0",
-    "uuid": "151ecca8-670b-4026-8160-cdd2679ef2bd",
-    "description": "Redux Robotics 2025 Beta",
-    "website": "https://docs.reduxrobotics.com/reduxlib"
-  },
-  {
+    "uuid": "c39481e8-4a63-4a4c-9df6-48d91e4da37b",
+    "name": "maplesim",
+    "description": "FRC Java Robot Simulation using a physics engine",
+    "website": "https://github.com/Shenzhen-Robotics-Alliance/maple-sim",
     "path": "2025beta/maple-sim-0.2.0.json",
-    "name": "maplesim",
-    "version": "0.2.0",
-    "uuid": "c39481e8-4a63-4a4c-9df6-48d91e4da37b",
-    "description": "FRC Java Robot Simulation using a physics engine",
-    "website": "https://github.com/Shenzhen-Robotics-Alliance/maple-sim"
+    "version": "0.2.0"
   },
   {
-    "path": "2025beta/maple-sim-0.2.2.json",
-    "name": "maplesim",
-    "version": "0.2.2",
-    "uuid": "c39481e8-4a63-4a4c-9df6-48d91e4da37b",
-    "description": "FRC Java Robot Simulation using a physics engine",
-    "website": "https://github.com/Shenzhen-Robotics-Alliance/maple-sim"
+    "uuid": "e7900d8d-826f-4dca-a1ff-182f658e98af",
+    "name": "CTRE-Phoenix Replay (v6)",
+    "description": "Libraries for Phoenix 6 devices with Hoot Replay",
+    "website": "https://docs.ctr-electronics.com/",
+    "path": "2025beta/Phoenix6-replay-25.0.0-beta-3.json",
+    "version": "25.0.0-beta-3"
   },
   {
-    "path": "2025beta/maple-sim-0.2.4.json",
-    "name": "maplesim",
-    "version": "0.2.4",
-    "uuid": "c39481e8-4a63-4a4c-9df6-48d91e4da37b",
-    "description": "FRC Java Robot Simulation using a physics engine",
-    "website": "https://github.com/Shenzhen-Robotics-Alliance/maple-sim"
+    "uuid": "e995de00-2c64-4df5-8831-c1441420ff19",
+    "name": "CTRE-Phoenix (v6)",
+    "description": "Libraries for Phoenix 6 devices",
+    "website": "https://docs.ctr-electronics.com/",
+    "path": "2025beta/Phoenix6-25.0.0-beta-2.json",
+    "version": "25.0.0-beta-2"
   },
   {
-    "path": "2025beta/yagsl.json",
-    "name": "Yet Another Generic Swerve Library (YAGSL)",
-    "version": "2025.0.0",
+    "uuid": "ab676553-b602-441f-a38d-f1296eff6537",
+    "name": "CTRE-Phoenix (v5)",
+    "description": "Libraries for Phoenix 5 devices",
+    "website": "https://docs.ctr-electronics.com/",
+    "path": "2025beta/Phoenix5-5.34.0-beta-1.json",
+    "version": "5.34.0-beta-1"
+  },
+  {
+    "uuid": "3f48eb8c-50fe-43a6-9cb7-44c86353c4cb",
+    "name": "REVLib",
+    "description": "Library for all REV devices including SPARK Flex, SPARK MAX, and Color Sensor V3",
+    "website": "https://docs.revrobotics.com/brushless/revlib/revlib-overview",
+    "path": "2025beta/REVLib-2025.0.0-beta-3.json",
+    "version": "2025.0.0-beta-3"
+  },
+  {
     "uuid": "1ccce5a4-acd2-4d18-bca3-4b8047188400",
+    "name": "Yet Another Generic Swerve Library (YAGSL)",
     "description": "YAGSL (Yet Another Generic Swerve Library) is an open-source robotics library designed to simplify and optimize the control, simulation, and configuration of swerve drive systems of all types.",
-    "website": "https://yagsl.gitbook.io/yagsl"
-  },
-  {
+    "website": "https://docs.yagsl.com/",
     "path": "2025beta/yagsl-2025.1.0.1.json",
-    "name": "Yet Another Generic Swerve Library (YAGSL)",
-    "version": "2025.1.0.1",
-    "uuid": "1ccce5a4-acd2-4d18-bca3-4b8047188400",
-    "description": "YAGSL (Yet Another Generic Swerve Library) is an open-source robotics library designed to simplify and optimize the control, simulation, and configuration of swerve drive systems of all types.",
-    "website": "https://docs.yagsl.com"
+    "version": "2025.1.0.1"
   },
   {
-    "path": "2025beta/yagsl-2025.1.0.3.json",
-    "name": "Yet Another Generic Swerve Library (YAGSL)",
-    "version": "2025.1.0.3",
+    "uuid": "cb311d09-36e9-4143-a032-55bb2b94443b",
+    "name": "Studica",
+    "description": "Libraries for NavX and other Studica Products",
+    "website": "https://github.com/Studica-Robotics/NavX/",
+    "path": "2025beta/Studica-2025.1.1-beta-3.json",
+    "version": "2025.1.1-beta-3"
+  },
+  {
+    "uuid": "1b42324f-17c6-4875-8e77-1c312bc8c786",
+    "name": "PathplannerLib",
+    "description": "PathPlanner's powerful robot-side vendor library",
+    "website": "https://pathplanner.dev/pathplannerlib.html",
+    "path": "2025beta/PathplannerLib-2025.0.0-beta-3.1.json",
+    "version": "2025.0.0-beta-3.1"
+  },
+  {
+    "uuid": "cb311d09-36e9-4143-a032-55bb2b94443b",
+    "name": "Studica",
+    "description": "Libraries for NavX and other Studica Products",
+    "website": "https://github.com/Studica-Robotics/NavX/",
+    "path": "2025beta/Studica-2025.1.1-beta-4.json",
+    "version": "2025.1.1-beta-4"
+  },
+  {
+    "uuid": "c39481e8-4a63-4a4c-9df6-48d91e4da37b",
+    "name": "maplesim",
+    "description": "FRC Java Robot Simulation using a physics engine",
+    "website": "https://github.com/Shenzhen-Robotics-Alliance/maple-sim",
+    "path": "2025beta/maple-sim-0.2.2.json",
+    "version": "0.2.2"
+  },
+  {
+    "uuid": "84246d17-a797-4d1e-bd9f-c59cd8d2477c",
+    "name": "URCL",
+    "description": "Unofficial REV-Compatible Logger for AdvantageScope",
+    "website": "https://docs.advantagescope.org/more-features/urcl",
+    "path": "2025beta/URCL-2025.0.0-beta-1.json",
+    "version": "2025.0.0-beta-1"
+  },
+  {
+    "uuid": "1b42324f-17c6-4875-8e77-1c312bc8c786",
+    "name": "PathplannerLib",
+    "description": "PathPlanner's powerful robot-side vendor library",
+    "website": "https://pathplanner.dev/pathplannerlib.html",
+    "path": "2025beta/PathplannerLib-2025.0.0-beta-3.json",
+    "version": "2025.0.0-beta-3"
+  },
+  {
+    "uuid": "e7900d8d-826f-4dca-a1ff-182f658e98af",
+    "name": "CTRE-Phoenix Replay (v6)",
+    "description": "Libraries for Phoenix 6 devices with Hoot Replay",
+    "website": "https://docs.ctr-electronics.com/",
+    "path": "2025beta/Phoenix6-replay-25.0.0-beta-1.json",
+    "version": "25.0.0-beta-1"
+  },
+  {
+    "uuid": "65592ce1-2251-4a31-8e4b-2df20dacebe4",
+    "name": "DogLog",
+    "description": "Simpler logging for FRC",
+    "website": "https://doglog.dev/",
+    "path": "2025beta/DogLog-2025.0.0.json",
+    "version": "2025.0.0"
+  },
+  {
+    "uuid": "ab676553-b602-441f-a38d-f1296eff6537",
+    "name": "CTRE-Phoenix (v5)",
+    "description": "Libraries for Phoenix 5 devices",
+    "website": "https://docs.ctr-electronics.com/",
+    "path": "2025beta/Phoenix5-5.34.0-beta-3.json",
+    "version": "5.34.0-beta-3"
+  },
+  {
+    "uuid": "e995de00-2c64-4df5-8831-c1441420ff19",
+    "name": "CTRE-Phoenix (v6)",
+    "description": "Libraries for Phoenix 6 devices",
+    "website": "https://docs.ctr-electronics.com/",
+    "path": "2025beta/Phoenix6-25.0.0-beta-1.json",
+    "version": "25.0.0-beta-1"
+  },
+  {
+    "uuid": "ab676553-b602-441f-a38d-f1296eff6537",
+    "name": "CTRE-Phoenix (v5)",
+    "description": "Libraries for Phoenix 5 devices",
+    "website": "https://docs.ctr-electronics.com/",
+    "path": "2025beta/Phoenix5-5.34.0-beta-2.json",
+    "version": "5.34.0-beta-2"
+  },
+  {
+    "uuid": "3f48eb8c-50fe-43a6-9cb7-44c86353c4cb",
+    "name": "REVLib",
+    "description": "Library for all REV devices including SPARK Flex, SPARK MAX, and Color Sensor V3",
+    "website": "https://docs.revrobotics.com/brushless/revlib/revlib-overview",
+    "path": "2025beta/REVLib-2025.0.0-beta-2.json",
+    "version": "2025.0.0-beta-2"
+  },
+  {
     "uuid": "1ccce5a4-acd2-4d18-bca3-4b8047188400",
+    "name": "Yet Another Generic Swerve Library (YAGSL)",
     "description": "YAGSL (Yet Another Generic Swerve Library) is an open-source robotics library designed to simplify and optimize the control, simulation, and configuration of swerve drive systems of all types.",
-    "website": "https://docs.yagsl.com"
+    "website": "https://docs.yagsl.com/",
+    "path": "2025beta/yagsl-2025.1.0.3.json",
+    "version": "2025.1.0.3"
+  },
+  {
+    "uuid": "151ecca8-670b-4026-8160-cdd2679ef2bd",
+    "name": "ReduxLib",
+    "description": "Redux Robotics 2025 Beta",
+    "website": "https://docs.reduxrobotics.com/reduxlib",
+    "path": "2025beta/ReduxLib_2025.json",
+    "version": "2025.0.0-beta0"
+  },
+  {
+    "uuid": "e7900d8d-826f-4dca-a1ff-182f658e98af",
+    "name": "CTRE-Phoenix Replay (v6)",
+    "description": "Libraries for Phoenix 6 devices with Hoot Replay",
+    "website": "https://docs.ctr-electronics.com/",
+    "path": "2025beta/Phoenix6-replay-25.0.0-beta-2.json",
+    "version": "25.0.0-beta-2"
+  },
+  {
+    "uuid": "1ccce5a4-acd2-4d18-bca3-4b8047188400",
+    "name": "Yet Another Generic Swerve Library (YAGSL)",
+    "description": "YAGSL (Yet Another Generic Swerve Library) is an open-source robotics library designed to simplify and optimize the control, simulation, and configuration of swerve drive systems of all types.",
+    "website": "https://docs.yagsl.com/",
+    "path": "2025beta/yagsl.json",
+    "version": "2025.0.0"
+  },
+  {
+    "uuid": "1b42324f-17c6-4875-8e77-1c312bc8c786",
+    "name": "PathplannerLib",
+    "description": "PathPlanner's powerful robot-side vendor library",
+    "website": "https://pathplanner.dev/pathplannerlib.html",
+    "path": "2025beta/PathplannerLib-2025.0.0-beta-4.json",
+    "version": "2025.0.0-beta-4"
+  },
+  {
+    "uuid": "e995de00-2c64-4df5-8831-c1441420ff19",
+    "name": "CTRE-Phoenix (v6)",
+    "description": "Libraries for Phoenix 6 devices",
+    "website": "https://docs.ctr-electronics.com/",
+    "path": "2025beta/Phoenix6-25.0.0-beta-3.json",
+    "version": "25.0.0-beta-3"
+  },
+  {
+    "uuid": "3f48eb8c-50fe-43a6-9cb7-44c86353c4cb",
+    "name": "REVLib",
+    "description": "Library for all REV devices including SPARK Flex, SPARK MAX, and Color Sensor V3",
+    "website": "https://docs.revrobotics.com/brushless/revlib/revlib-overview",
+    "path": "2025beta/REVLib-2025.0.0-beta-1.json",
+    "version": "2025.0.0-beta-1"
+  },
+  {
+    "uuid": "c39481e8-4a63-4a4c-9df6-48d91e4da37b",
+    "name": "maplesim",
+    "description": "FRC Java Robot Simulation using a physics engine",
+    "website": "https://github.com/Shenzhen-Robotics-Alliance/maple-sim",
+    "path": "2025beta/maple-sim-0.2.4.json",
+    "version": "0.2.4"
   }
 ]

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@rules_python//python:defs.bzl", "py_binary")
 load("@rules_python//python:pip.bzl", "compile_pip_requirements")
 load("@vendor-json-repo-pip//:requirements.bzl", "requirement")
@@ -27,10 +28,16 @@ py_binary(
     visibility = ["//visibility:public"],
 )
 
+py_binary(
+    name = "generate_year_bundles",
+    srcs = ["generate_year_bundles.py"],
+)
+
 # Change this for local testing only.
 cache_directory = None
 
 YEAR_2024_FILES = glob(["2024/*.json"])
+
 [vendordep_check_test(
     allowable_errors = 1,
     allowable_warnings = None,
@@ -40,10 +47,42 @@ YEAR_2024_FILES = glob(["2024/*.json"])
 # year_bundle_test(year="2024", year_files=YEAR_2024_FILES) # Disable the test because there a several invalid entries
 
 YEAR_2025BETA_FILES = glob(["2025beta/*.json"])
+
 [vendordep_check_test(
     allowable_errors = 0,
     allowable_warnings = None,
     cache_directory = cache_directory,
     vendor_file = f,
 ) for f in YEAR_2025BETA_FILES]
-year_bundle_test(year="2025beta", year_files=YEAR_2025BETA_FILES)
+
+year_bundle_test(
+    year = "2025beta",
+    year_files = YEAR_2025BETA_FILES,
+)
+
+# TODO temporarily generate bundles files in-tree, to maintain compatability with released beta VS Code plugins
+[genrule(
+    name = "generate_" + year + "_year_bundle_rule",
+    srcs = glob([year + "/*.json"]) + [
+        year + ".json",
+        year + "_metadata.json",
+    ],
+    outs = ["bundles/" + year + ".json"],
+    cmd = "$(locations :generate_year_bundles) -o $(OUTS) " + year,
+    tools = [":generate_year_bundles"],
+) for year in [
+    "2024",
+    "2025beta",
+]]
+
+[write_source_files(
+    name = "write_" + year + "_year_bundle",
+    files = {
+        year + ".json": ":generate_" + year + "_year_bundle_rule",
+    },
+    suggested_update_target = "//:write_all",
+    visibility = ["//visibility:public"],
+) for year in [
+    "2024",
+    "2025beta",
+]]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,6 +5,7 @@ module(
 )
 
 bazel_dep(name = "rules_python", version = "0.37.0")
+bazel_dep(name = "aspect_bazel_lib", version = "2.7.2")
 
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")
 python.toolchain(

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -9,6 +9,8 @@
     "https://bcr.bazel.build/modules/abseil-cpp/20230802.0.bcr.1/source.json": "14892cc698e02ffedf4967546e6bedb7245015906888d3465fcf27c90a26da10",
     "https://bcr.bazel.build/modules/apple_support/1.5.0/MODULE.bazel": "50341a62efbc483e8a2a6aec30994a58749bd7b885e18dd96aa8c33031e558ef",
     "https://bcr.bazel.build/modules/apple_support/1.5.0/source.json": "eb98a7627c0bc486b57f598ad8da50f6625d974c8f723e9ea71bd39f709c9862",
+    "https://bcr.bazel.build/modules/aspect_bazel_lib/2.7.2/MODULE.bazel": "780d1a6522b28f5edb7ea09630748720721dfe27690d65a2d33aa7509de77e07",
+    "https://bcr.bazel.build/modules/aspect_bazel_lib/2.7.2/source.json": "a9ee2898e86eb8106e67b2adcd63de788cd922dd82f90f6775f13b0bf2248d75",
     "https://bcr.bazel.build/modules/bazel_features/1.11.0/MODULE.bazel": "f9382337dd5a474c3b7d334c2f83e50b6eaedc284253334cf823044a26de03e8",
     "https://bcr.bazel.build/modules/bazel_features/1.11.0/source.json": "c9320aa53cd1c441d24bd6b716da087ad7e4ff0d9742a9884587596edfe53015",
     "https://bcr.bazel.build/modules/bazel_features/1.9.1/MODULE.bazel": "8f679097876a9b609ad1f60249c49d68bfab783dd9be012faf9d82547b14815a",
@@ -46,10 +48,11 @@
     "https://bcr.bazel.build/modules/rules_cc/0.0.9/MODULE.bazel": "836e76439f354b89afe6a911a7adf59a6b2518fafb174483ad78a2a2fde7b1c5",
     "https://bcr.bazel.build/modules/rules_cc/0.0.9/source.json": "1f1ba6fea244b616de4a554a0f4983c91a9301640c8fe0dd1d410254115c8430",
     "https://bcr.bazel.build/modules/rules_java/4.0.0/MODULE.bazel": "5a78a7ae82cd1a33cef56dc578c7d2a46ed0dca12643ee45edbb8417899e6f74",
+    "https://bcr.bazel.build/modules/rules_java/5.3.5/MODULE.bazel": "a4ec4f2db570171e3e5eb753276ee4b389bae16b96207e9d3230895c99644b86",
     "https://bcr.bazel.build/modules/rules_java/6.3.0/MODULE.bazel": "a97c7678c19f236a956ad260d59c86e10a463badb7eb2eda787490f4c969b963",
     "https://bcr.bazel.build/modules/rules_java/7.1.0/MODULE.bazel": "30d9135a2b6561c761bd67bd4990da591e6bdc128790ce3e7afd6a3558b2fb64",
-    "https://bcr.bazel.build/modules/rules_java/7.6.5/MODULE.bazel": "481164be5e02e4cab6e77a36927683263be56b7e36fef918b458d7a8a1ebadb1",
-    "https://bcr.bazel.build/modules/rules_java/7.6.5/source.json": "a805b889531d1690e3c72a7a7e47a870d00323186a9904b36af83aa3d053ee8d",
+    "https://bcr.bazel.build/modules/rules_java/7.6.1/MODULE.bazel": "2f14b7e8a1aa2f67ae92bc69d1ec0fa8d9f827c4e17ff5e5f02e91caa3b2d0fe",
+    "https://bcr.bazel.build/modules/rules_java/7.6.1/source.json": "8f3f3076554e1558e8e468b2232991c510ecbcbed9e6f8c06ac31c93bcf38362",
     "https://bcr.bazel.build/modules/rules_jvm_external/4.4.2/MODULE.bazel": "a56b85e418c83eb1839819f0b515c431010160383306d13ec21959ac412d2fe7",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.1/MODULE.bazel": "33f6f999e03183f7d088c9be518a63467dfd0be94a11d0055fe2d210f89aa909",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.2/MODULE.bazel": "d9351ba35217ad0de03816ef3ed63f89d411349353077348a45348b096615036",
@@ -70,6 +73,7 @@
     "https://bcr.bazel.build/modules/rules_python/0.4.0/MODULE.bazel": "9208ee05fd48bf09ac60ed269791cf17fb343db56c8226a720fbb1cdf467166c",
     "https://bcr.bazel.build/modules/stardoc/0.5.1/MODULE.bazel": "1a05d92974d0c122f5ccf09291442580317cdd859f07a8655f1db9a60374f9f8",
     "https://bcr.bazel.build/modules/stardoc/0.5.3/MODULE.bazel": "c7f6948dae6999bf0db32c1858ae345f112cacf98f174c7a8bb707e41b974f1c",
+    "https://bcr.bazel.build/modules/stardoc/0.5.4/MODULE.bazel": "6569966df04610b8520957cb8e97cf2e9faac2c0309657c537ab51c16c18a2a4",
     "https://bcr.bazel.build/modules/stardoc/0.6.2/MODULE.bazel": "7060193196395f5dd668eda046ccbeacebfd98efc77fed418dbe2b82ffaa39fd",
     "https://bcr.bazel.build/modules/stardoc/0.6.2/source.json": "d2ff8063b63b4a85e65fe595c4290f99717434fa9f95b4748a79a7d04dfed349",
     "https://bcr.bazel.build/modules/upb/0.0.0-20220923-a547704/MODULE.bazel": "7298990c00040a0e2f121f6c32544bab27d4452f80d9ce51349b1a28f3005c43",
@@ -77,8 +81,8 @@
     "https://bcr.bazel.build/modules/upb/0.0.0-20230516-61a97ef/source.json": "b2150404947339e8b947c6b16baa39fa75657f4ddec5e37272c7b11c7ab533bc",
     "https://bcr.bazel.build/modules/zlib/1.2.11/MODULE.bazel": "07b389abc85fdbca459b69e2ec656ae5622873af3f845e1c9d80fe179f3effa0",
     "https://bcr.bazel.build/modules/zlib/1.2.12/MODULE.bazel": "3b1a8834ada2a883674be8cbd36ede1b6ec481477ada359cd2d3ddc562340b27",
-    "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.3/MODULE.bazel": "af322bc08976524477c79d1e45e241b6efbeb918c497e8840b8ab116802dda79",
-    "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.3/source.json": "2be409ac3c7601245958cd4fcdff4288be79ed23bd690b4b951f500d54ee6e7d"
+    "https://bcr.bazel.build/modules/zlib/1.3/MODULE.bazel": "6a9c02f19a24dcedb05572b2381446e27c272cd383aed11d41d99da9e3167a72",
+    "https://bcr.bazel.build/modules/zlib/1.3/source.json": "b6b43d0737af846022636e6e255fd4a96fee0d34f08f3830e6e0bac51465c37c"
   },
   "selectedYankedVersions": {},
   "moduleExtensions": {
@@ -104,6 +108,473 @@
         "recordedRepoMappingEntries": [
           [
             "apple_support~",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@aspect_bazel_lib~//lib:extensions.bzl%toolchains": {
+      "general": {
+        "bzlTransitiveDigest": "nzNCCKeGDuuaB6uzXddNTVOHkFu9zZDzQ37VqiZh/Sg=",
+        "usagesDigest": "n+yrTrm4xzV00YZYTm9knMaVDgXeFk+oC8MPpuAF/p8=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "expand_template_windows_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:expand_template_toolchain.bzl",
+            "ruleClassName": "expand_template_platform_repo",
+            "attributes": {
+              "platform": "windows_amd64"
+            }
+          },
+          "copy_to_directory_windows_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:copy_to_directory_toolchain.bzl",
+            "ruleClassName": "copy_to_directory_platform_repo",
+            "attributes": {
+              "platform": "windows_amd64"
+            }
+          },
+          "jq_darwin_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:jq_toolchain.bzl",
+            "ruleClassName": "jq_platform_repo",
+            "attributes": {
+              "platform": "darwin_amd64",
+              "version": "1.7"
+            }
+          },
+          "copy_to_directory_freebsd_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:copy_to_directory_toolchain.bzl",
+            "ruleClassName": "copy_to_directory_platform_repo",
+            "attributes": {
+              "platform": "freebsd_amd64"
+            }
+          },
+          "expand_template_linux_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:expand_template_toolchain.bzl",
+            "ruleClassName": "expand_template_platform_repo",
+            "attributes": {
+              "platform": "linux_amd64"
+            }
+          },
+          "jq_linux_arm64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:jq_toolchain.bzl",
+            "ruleClassName": "jq_platform_repo",
+            "attributes": {
+              "platform": "linux_arm64",
+              "version": "1.7"
+            }
+          },
+          "coreutils_darwin_arm64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:coreutils_toolchain.bzl",
+            "ruleClassName": "coreutils_platform_repo",
+            "attributes": {
+              "platform": "darwin_arm64",
+              "version": "0.0.23"
+            }
+          },
+          "copy_to_directory_linux_arm64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:copy_to_directory_toolchain.bzl",
+            "ruleClassName": "copy_to_directory_platform_repo",
+            "attributes": {
+              "platform": "linux_arm64"
+            }
+          },
+          "bsd_tar_linux_arm64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:tar_toolchain.bzl",
+            "ruleClassName": "bsdtar_binary_repo",
+            "attributes": {
+              "platform": "linux_arm64"
+            }
+          },
+          "copy_directory_darwin_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:copy_directory_toolchain.bzl",
+            "ruleClassName": "copy_directory_platform_repo",
+            "attributes": {
+              "platform": "darwin_amd64"
+            }
+          },
+          "coreutils_darwin_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:coreutils_toolchain.bzl",
+            "ruleClassName": "coreutils_platform_repo",
+            "attributes": {
+              "platform": "darwin_amd64",
+              "version": "0.0.23"
+            }
+          },
+          "coreutils_linux_arm64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:coreutils_toolchain.bzl",
+            "ruleClassName": "coreutils_platform_repo",
+            "attributes": {
+              "platform": "linux_arm64",
+              "version": "0.0.23"
+            }
+          },
+          "zstd_linux_arm64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:zstd_toolchain.bzl",
+            "ruleClassName": "zstd_binary_repo",
+            "attributes": {
+              "platform": "linux_arm64"
+            }
+          },
+          "yq_linux_s390x": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:yq_toolchain.bzl",
+            "ruleClassName": "yq_platform_repo",
+            "attributes": {
+              "platform": "linux_s390x",
+              "version": "4.25.2"
+            }
+          },
+          "yq": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:yq_toolchain.bzl",
+            "ruleClassName": "yq_host_alias_repo",
+            "attributes": {}
+          },
+          "expand_template_darwin_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:expand_template_toolchain.bzl",
+            "ruleClassName": "expand_template_platform_repo",
+            "attributes": {
+              "platform": "darwin_amd64"
+            }
+          },
+          "copy_directory_linux_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:copy_directory_toolchain.bzl",
+            "ruleClassName": "copy_directory_platform_repo",
+            "attributes": {
+              "platform": "linux_amd64"
+            }
+          },
+          "jq_darwin_arm64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:jq_toolchain.bzl",
+            "ruleClassName": "jq_platform_repo",
+            "attributes": {
+              "platform": "darwin_arm64",
+              "version": "1.7"
+            }
+          },
+          "yq_darwin_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:yq_toolchain.bzl",
+            "ruleClassName": "yq_platform_repo",
+            "attributes": {
+              "platform": "darwin_amd64",
+              "version": "4.25.2"
+            }
+          },
+          "copy_directory_linux_arm64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:copy_directory_toolchain.bzl",
+            "ruleClassName": "copy_directory_platform_repo",
+            "attributes": {
+              "platform": "linux_arm64"
+            }
+          },
+          "expand_template_toolchains": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:expand_template_toolchain.bzl",
+            "ruleClassName": "expand_template_toolchains_repo",
+            "attributes": {
+              "user_repository_name": "expand_template"
+            }
+          },
+          "bats_assert": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "98ca3b685f8b8993e48ec057565e6e2abcc541034ed5b0e81f191505682037fd",
+              "urls": [
+                "https://github.com/bats-core/bats-assert/archive/v2.1.0.tar.gz"
+              ],
+              "strip_prefix": "bats-assert-2.1.0",
+              "build_file_content": "load(\"@aspect_bazel_lib//lib:copy_to_directory.bzl\", \"copy_to_directory\")\n\ncopy_to_directory(\n    name = \"assert\",\n    hardlink = \"on\",\n    srcs = glob([\n        \"src/**\",\n        \"load.bash\",\n    ]),\n    out = \"bats-assert\",\n    visibility = [\"//visibility:public\"]\n)\n"
+            }
+          },
+          "copy_to_directory_darwin_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:copy_to_directory_toolchain.bzl",
+            "ruleClassName": "copy_to_directory_platform_repo",
+            "attributes": {
+              "platform": "darwin_amd64"
+            }
+          },
+          "zstd_darwin_arm64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:zstd_toolchain.bzl",
+            "ruleClassName": "zstd_binary_repo",
+            "attributes": {
+              "platform": "darwin_arm64"
+            }
+          },
+          "bsd_tar_linux_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:tar_toolchain.bzl",
+            "ruleClassName": "bsdtar_binary_repo",
+            "attributes": {
+              "platform": "linux_amd64"
+            }
+          },
+          "yq_toolchains": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:yq_toolchain.bzl",
+            "ruleClassName": "yq_toolchains_repo",
+            "attributes": {
+              "user_repository_name": "yq"
+            }
+          },
+          "zstd_linux_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:zstd_toolchain.bzl",
+            "ruleClassName": "zstd_binary_repo",
+            "attributes": {
+              "platform": "linux_amd64"
+            }
+          },
+          "bats_support": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "7815237aafeb42ddcc1b8c698fc5808026d33317d8701d5ec2396e9634e2918f",
+              "urls": [
+                "https://github.com/bats-core/bats-support/archive/v0.3.0.tar.gz"
+              ],
+              "strip_prefix": "bats-support-0.3.0",
+              "build_file_content": "load(\"@aspect_bazel_lib//lib:copy_to_directory.bzl\", \"copy_to_directory\")\n\ncopy_to_directory(\n    name = \"support\",\n    hardlink = \"on\",\n    srcs = glob([\n        \"src/**\",\n        \"load.bash\",\n    ]),\n    out = \"bats-support\",\n    visibility = [\"//visibility:public\"]\n)\n"
+            }
+          },
+          "bsd_tar_windows_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:tar_toolchain.bzl",
+            "ruleClassName": "bsdtar_binary_repo",
+            "attributes": {
+              "platform": "windows_amd64"
+            }
+          },
+          "jq": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:jq_toolchain.bzl",
+            "ruleClassName": "jq_host_alias_repo",
+            "attributes": {}
+          },
+          "expand_template_darwin_arm64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:expand_template_toolchain.bzl",
+            "ruleClassName": "expand_template_platform_repo",
+            "attributes": {
+              "platform": "darwin_arm64"
+            }
+          },
+          "bsd_tar_darwin_arm64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:tar_toolchain.bzl",
+            "ruleClassName": "bsdtar_binary_repo",
+            "attributes": {
+              "platform": "darwin_arm64"
+            }
+          },
+          "copy_to_directory_linux_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:copy_to_directory_toolchain.bzl",
+            "ruleClassName": "copy_to_directory_platform_repo",
+            "attributes": {
+              "platform": "linux_amd64"
+            }
+          },
+          "coreutils_linux_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:coreutils_toolchain.bzl",
+            "ruleClassName": "coreutils_platform_repo",
+            "attributes": {
+              "platform": "linux_amd64",
+              "version": "0.0.23"
+            }
+          },
+          "copy_directory_toolchains": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:copy_directory_toolchain.bzl",
+            "ruleClassName": "copy_directory_toolchains_repo",
+            "attributes": {
+              "user_repository_name": "copy_directory"
+            }
+          },
+          "yq_linux_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:yq_toolchain.bzl",
+            "ruleClassName": "yq_platform_repo",
+            "attributes": {
+              "platform": "linux_amd64",
+              "version": "4.25.2"
+            }
+          },
+          "copy_to_directory_darwin_arm64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:copy_to_directory_toolchain.bzl",
+            "ruleClassName": "copy_to_directory_platform_repo",
+            "attributes": {
+              "platform": "darwin_arm64"
+            }
+          },
+          "coreutils_toolchains": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:coreutils_toolchain.bzl",
+            "ruleClassName": "coreutils_toolchains_repo",
+            "attributes": {
+              "user_repository_name": "coreutils"
+            }
+          },
+          "copy_directory_freebsd_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:copy_directory_toolchain.bzl",
+            "ruleClassName": "copy_directory_platform_repo",
+            "attributes": {
+              "platform": "freebsd_amd64"
+            }
+          },
+          "zstd_darwin_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:zstd_toolchain.bzl",
+            "ruleClassName": "zstd_binary_repo",
+            "attributes": {
+              "platform": "darwin_amd64"
+            }
+          },
+          "zstd_toolchains": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:zstd_toolchain.bzl",
+            "ruleClassName": "zstd_toolchains_repo",
+            "attributes": {
+              "user_repository_name": "zstd"
+            }
+          },
+          "bats_file": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "9b69043241f3af1c2d251f89b4fcafa5df3f05e97b89db18d7c9bdf5731bb27a",
+              "urls": [
+                "https://github.com/bats-core/bats-file/archive/v0.4.0.tar.gz"
+              ],
+              "strip_prefix": "bats-file-0.4.0",
+              "build_file_content": "load(\"@aspect_bazel_lib//lib:copy_to_directory.bzl\", \"copy_to_directory\")\n\ncopy_to_directory(\n    name = \"file\",\n    hardlink = \"on\",\n    srcs = glob([\n        \"src/**\",\n        \"load.bash\",\n    ]),\n    out = \"bats-file\",\n    visibility = [\"//visibility:public\"]\n)\n"
+            }
+          },
+          "expand_template_linux_arm64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:expand_template_toolchain.bzl",
+            "ruleClassName": "expand_template_platform_repo",
+            "attributes": {
+              "platform": "linux_arm64"
+            }
+          },
+          "jq_linux_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:jq_toolchain.bzl",
+            "ruleClassName": "jq_platform_repo",
+            "attributes": {
+              "platform": "linux_amd64",
+              "version": "1.7"
+            }
+          },
+          "bsd_tar_darwin_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:tar_toolchain.bzl",
+            "ruleClassName": "bsdtar_binary_repo",
+            "attributes": {
+              "platform": "darwin_amd64"
+            }
+          },
+          "bsd_tar_toolchains": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:tar_toolchain.bzl",
+            "ruleClassName": "tar_toolchains_repo",
+            "attributes": {
+              "user_repository_name": "bsd_tar"
+            }
+          },
+          "bats_toolchains": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "a1a9f7875aa4b6a9480ca384d5865f1ccf1b0b1faead6b47aa47d79709a5c5fd",
+              "urls": [
+                "https://github.com/bats-core/bats-core/archive/v1.10.0.tar.gz"
+              ],
+              "strip_prefix": "bats-core-1.10.0",
+              "build_file_content": "load(\"@local_config_platform//:constraints.bzl\", \"HOST_CONSTRAINTS\")\nload(\"@aspect_bazel_lib//lib/private:bats_toolchain.bzl\", \"bats_toolchain\")\nload(\"@aspect_bazel_lib//lib:copy_to_directory.bzl\", \"copy_to_directory\")\n\ncopy_to_directory(\n    name = \"core\",\n    hardlink = \"on\",\n    srcs = glob([\n        \"lib/**\",\n        \"libexec/**\"\n    ]) + [\"bin/bats\"],\n    out = \"bats-core\",\n)\n\nbats_toolchain(\n    name = \"toolchain\",\n    core = \":core\",\n    libraries = [\"@bats_support//:support\", \"@bats_assert//:assert\", \"@bats_file//:file\"]\n)\n\ntoolchain(\n    name = \"bats_toolchain\",\n    exec_compatible_with = HOST_CONSTRAINTS,\n    toolchain = \":toolchain\",\n    toolchain_type = \"@aspect_bazel_lib//lib:bats_toolchain_type\",\n)\n"
+            }
+          },
+          "yq_windows_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:yq_toolchain.bzl",
+            "ruleClassName": "yq_platform_repo",
+            "attributes": {
+              "platform": "windows_amd64",
+              "version": "4.25.2"
+            }
+          },
+          "jq_windows_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:jq_toolchain.bzl",
+            "ruleClassName": "jq_platform_repo",
+            "attributes": {
+              "platform": "windows_amd64",
+              "version": "1.7"
+            }
+          },
+          "expand_template_freebsd_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:expand_template_toolchain.bzl",
+            "ruleClassName": "expand_template_platform_repo",
+            "attributes": {
+              "platform": "freebsd_amd64"
+            }
+          },
+          "yq_linux_ppc64le": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:yq_toolchain.bzl",
+            "ruleClassName": "yq_platform_repo",
+            "attributes": {
+              "platform": "linux_ppc64le",
+              "version": "4.25.2"
+            }
+          },
+          "copy_to_directory_toolchains": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:copy_to_directory_toolchain.bzl",
+            "ruleClassName": "copy_to_directory_toolchains_repo",
+            "attributes": {
+              "user_repository_name": "copy_to_directory"
+            }
+          },
+          "jq_toolchains": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:jq_toolchain.bzl",
+            "ruleClassName": "jq_toolchains_repo",
+            "attributes": {
+              "user_repository_name": "jq"
+            }
+          },
+          "copy_directory_darwin_arm64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:copy_directory_toolchain.bzl",
+            "ruleClassName": "copy_directory_platform_repo",
+            "attributes": {
+              "platform": "darwin_arm64"
+            }
+          },
+          "copy_directory_windows_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:copy_directory_toolchain.bzl",
+            "ruleClassName": "copy_directory_platform_repo",
+            "attributes": {
+              "platform": "windows_amd64"
+            }
+          },
+          "yq_darwin_arm64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:yq_toolchain.bzl",
+            "ruleClassName": "yq_platform_repo",
+            "attributes": {
+              "platform": "darwin_arm64",
+              "version": "4.25.2"
+            }
+          },
+          "coreutils_windows_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:coreutils_toolchain.bzl",
+            "ruleClassName": "coreutils_platform_repo",
+            "attributes": {
+              "platform": "windows_amd64",
+              "version": "0.0.23"
+            }
+          },
+          "yq_linux_arm64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:yq_toolchain.bzl",
+            "ruleClassName": "yq_platform_repo",
+            "attributes": {
+              "platform": "linux_arm64",
+              "version": "4.25.2"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "aspect_bazel_lib~",
+            "aspect_bazel_lib",
+            "aspect_bazel_lib~"
+          ],
+          [
+            "aspect_bazel_lib~",
+            "bazel_skylib",
+            "bazel_skylib~"
+          ],
+          [
+            "aspect_bazel_lib~",
             "bazel_tools",
             "bazel_tools"
           ]

--- a/generate_year_bundles.py
+++ b/generate_year_bundles.py
@@ -93,6 +93,10 @@ def main():
     )
     args = parser.parse_args()
 
+    # Helper for running with bazel
+    if not args.output.is_dir():
+        args.output = args.output.parent
+
     for year in args.year:
         generate_bundle(year, args.root, args.output)
 

--- a/test_utils.bzl
+++ b/test_utils.bzl
@@ -91,7 +91,7 @@ class VendordepCheck(unittest.TestCase):
 if __name__ == "__main__":
     unittest.main() # run all tests
 
-""".format(year=year)
+""".format(year = year)
 
     native.genrule(
         name = gen_name,


### PR DESCRIPTION
As per [this](https://github.com/wpilibsuite/vendor-json-repo/pull/60#discussion_r1891035712) comment, the in-tree bundle files are necessary for backwards compatibility with early beta VS code releases. However, they currently do not match the generated files that the plugin actually uses.

This adds an automatic test to generate the files and compare the outputs to the in tree file with bazel. Running `bazel test //...` will test it, and you can run with `bazel run //:write_2024_year_bundle`