### PR TITLE
Add PlayingWithFusion Packages

### DIFF
--- a/2025/playingwithfusion-2025.01.03.json
+++ b/2025/playingwithfusion-2025.01.03.json
@@ -1,0 +1,74 @@
+{
+    "fileName": "playingwithfusion2024.json",
+    "name": "PlayingWithFusion",
+    "version": "2025.01.03",
+    "uuid": "14b8ad04-24df-11ea-978f-2e728ce88125",
+    "frcYear": "2025",
+    "jsonUrl": "https://www.playingwithfusion.com/frc/playingwithfusion2025.json",
+    "mavenUrls": [
+        "https://www.playingwithfusion.com/frc/maven/"
+    ],
+    "javaDependencies": [
+        {
+            "groupId": "com.playingwithfusion.frc",
+            "artifactId": "PlayingWithFusion-java",
+            "version": "2025.01.03"
+        }
+    ],
+    "jniDependencies": [
+        {
+            "groupId": "com.playingwithfusion.frc",
+            "artifactId": "PlayingWithFusion-driver",
+            "version": "2025.01.03",
+            "skipInvalidPlatforms": true,
+            "isJar": false,
+            "validPlatforms": [
+                "windowsx86-64",
+                "windowsx86",
+                "linuxarm64",
+                "linuxx86-64",
+                "linuxathena",
+                "linuxarm32",
+                "osxuniversal"
+            ]
+        }
+    ],
+    "cppDependencies": [
+        {
+            "groupId": "com.playingwithfusion.frc",
+            "artifactId": "PlayingWithFusion-cpp",
+            "version": "2025.01.03",
+            "headerClassifier": "headers",
+            "sharedLibrary": false,
+            "libName": "PlayingWithFusion",
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "windowsx86",
+                "linuxarm64",
+                "linuxx86-64",
+                "linuxathena",
+                "linuxarm32",
+                "osxuniversal"
+            ]
+        },
+        {
+            "groupId": "com.playingwithfusion.frc",
+            "artifactId": "PlayingWithFusion-driver",
+            "version": "2025.01.03",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "libName": "PlayingWithFusionDriver",
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "windowsx86",
+                "linuxarm64",
+                "linuxx86-64",
+                "linuxathena",
+                "linuxarm32",
+                "osxuniversal"
+            ]
+        }
+    ]
+}

--- a/2025/playingwithfusion-2025.01.03.json
+++ b/2025/playingwithfusion-2025.01.03.json
@@ -1,5 +1,5 @@
 {
-    "fileName": "playingwithfusion2024.json",
+    "fileName": "playingwithfusion2025.json",
     "name": "PlayingWithFusion",
     "version": "2025.01.03",
     "uuid": "14b8ad04-24df-11ea-978f-2e728ce88125",

--- a/2025_metadata.json
+++ b/2025_metadata.json
@@ -83,5 +83,11 @@
     "name": "ChoreoLib",
     "description": "Library for Choreo trajectory following",
     "website": "https://github.com/SleipnirGroup/Choreo"
+  },
+  {
+    "uuid": "14b8ad04-24df-11ea-978f-2e728ce88125",
+    "name": "PlayingWithFusion",
+    "description": "Library for all PlayingWithFusion devices including Venom motor controllers and the Time of Flight sensor.",
+    "website": "https://www.playingwithfusion.com/static/frc.php"
   }
 ]


### PR DESCRIPTION
Hi there,

I've been emailing the PlayingWithFusion developers as they didn't have the package released for the 2025 season initially on kickoff. They just released it today, so I figured I would add it to the WPILib Vendor JSON so that everyone can access it. It's kinda hard to find on their website.

This package is used for the Venom motors and the sensors that they provide on their website.

I did want to note that on my commit "yep" I changed the file name from playingwithfusion2024 to 2025 as I noticed that they didn't do that on their release. Works on our robot, however, so I believe this is fine.

Hopefully, I did this alright, please let me know if I messed something up. I'm more than happy to correct my mistake.