### PR TITLE
Add supported languages to bundle entry schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ This manifest is a JSON file and consists at minimum of a list of dicts (one cor
 * `uuid`: the same as the uuid in the vendor JSON file
 * `description`: a user-friendly brief description of the library (intended to be displayed to users)
 * `website`: URL of the vendor's website (e.g. a site with documentation / tutorials / tools installers)
+* `languages`: an array of strings indicating the languages supported by the library. Currently used values are "cpp" and "java".
 
 Additionally, the following optional keys may be present in a manifest entry:
 

--- a/generate_bundles.py
+++ b/generate_bundles.py
@@ -3,6 +3,24 @@ import json
 import shutil
 from pathlib import Path
 
+def check_languages(vendordep_data: dict) -> list[str]:
+    # Check if json explicitly specifies and use that first
+    if "languages" in vendordep_data:
+        return vendordep_data["languages"]
+
+    languages = []
+    if (
+        "javaDependencies" in vendordep_data
+        and len(vendordep_data["javaDependencies"]) != 0
+    ):
+        languages.append("java")
+    if (
+        "cppDependencies" in vendordep_data
+        and len(vendordep_data["cppDependencies"]) != 0
+    ):
+        languages.append("cpp")
+    return languages
+
 
 def check_metadata_schema(metadata: list[dict]):
     required_keys = {"uuid", "name", "website", "description"}
@@ -38,6 +56,7 @@ def generate_entry(
     return metadata | {
         "path": path_prefix + file.name,
         "version": vendordep_data["version"],
+        "languages": check_languages(vendordep_data),
     }
 
 


### PR DESCRIPTION
Closes #79.

This is a per-vendordep-version option. The bundle generator will automatically detect languages from the library artifacts; if the library author wishes to override this automatic detection they can specify the desired supported languages via a root level `languages` key in their vendordep json.