### PR TITLE
Fixup for wpilibYear

### DIFF
--- a/add_vendordep.py
+++ b/add_vendordep.py
@@ -6,7 +6,8 @@ import shutil
 
 def add_vendordep(vendordep_filename):
     vendordep_contents = json.loads(vendordep_filename.read_bytes())
-    year = vendordep_contents["wpilibYear"]
+    # Uses dict default value as a fallback, remove after 2026
+    year = vendordep_contents.get("wpilibYear", vendordep_contents["frcYear"])
 
     metadata_filename = Path(f"{year}_metadata.json")
     metadata_contents = json.loads(metadata_filename.read_bytes())

--- a/add_vendordep.py
+++ b/add_vendordep.py
@@ -7,7 +7,11 @@ import shutil
 def add_vendordep(vendordep_filename):
     vendordep_contents = json.loads(vendordep_filename.read_bytes())
     # Uses dict default value as a fallback, remove after 2026
-    year = vendordep_contents.get("wpilibYear", vendordep_contents["frcYear"])
+    year = vendordep_contents.get("wpilibYear", vendordep_contents.get("frcYear"))
+    if year is None:
+        raise Exception(
+            "Vendordep file does not contain a year. Please add a wpilibYear field to the vendordep file."
+        )
 
     metadata_filename = Path(f"{year}_metadata.json")
     metadata_contents = json.loads(metadata_filename.read_bytes())

--- a/add_vendordep.py
+++ b/add_vendordep.py
@@ -6,8 +6,7 @@ import shutil
 
 def add_vendordep(vendordep_filename):
     vendordep_contents = json.loads(vendordep_filename.read_bytes())
-    # Uses dict default value as a fallback, remove after 2026
-    year = vendordep_contents.get("wpilibYear", vendordep_contents["frcYear"])
+    year = vendordep_contents["wpilibYear"]
 
     metadata_filename = Path(f"{year}_metadata.json")
     metadata_contents = json.loads(metadata_filename.read_bytes())


### PR DESCRIPTION
In #313 we switch from using frcYear to using wpilibYear with frcYear as a fallback. However, the implementation was incorrect. This PR fixes it. The script was tested on a photonvision vendordep, and it succesfully added the vendordep to the correct folder in the repo.
