### PR TITLE
Fix ThriftyLib 2027 alpha jsonUrl

### DIFF
--- a/2027_alpha5/ThriftyLib-2027.0.0-alpha-1.json
+++ b/2027_alpha5/ThriftyLib-2027.0.0-alpha-1.json
@@ -7,7 +7,7 @@
     "mavenUrls": [
         "https://docs.home.thethriftybot.com"
     ],
-    "jsonUrl": "https://docs.home.thethriftybot.com/software/thriftylib",
+    "jsonUrl": "https://docs.home.thethriftybot.com/software/thriftylib/ThriftyLib.json",
     "javaDependencies": [
         {
             "groupId": "com.thrifty.frc",

--- a/2027_alpha5/ThriftyLib-2027.0.0-alpha-2.json
+++ b/2027_alpha5/ThriftyLib-2027.0.0-alpha-2.json
@@ -7,7 +7,7 @@
     "mavenUrls": [
         "https://docs.home.thethriftybot.com"
     ],
-    "jsonUrl": "https://docs.home.thethriftybot.com/software/thriftylib",
+    "jsonUrl": "https://docs.home.thethriftybot.com/software/thriftylib/ThriftyLib.json",
     "javaDependencies": [
         {
             "groupId": "com.thrifty.frc",


### PR DESCRIPTION
The `jsonUrl` pointed at the /software/thriftylib folder, which after our docs domain change redirects to the main docs page and not the folder containing the json file. This fixes that by pointing to the specific json file.