### PR TITLE
Fixed yams by removing deleted CPP versions

### DIFF
--- a/2026/yams-2026.6.12.1.json
+++ b/2026/yams-2026.6.12.1.json
@@ -15,25 +15,7 @@
       "version": "2026.6.12.1"
     }
   ],
-  "cppDependencies": [
-    {
-      "groupId": "yams",
-      "artifactId": "YAMS-cpp",
-      "version": "2026.6.12.1",
-      "libName": "YAMS",
-      "headerClassifier": "headers",
-      "sharedLibrary": true,
-      "skipInvalidPlatforms": true,
-      "binaryPlatforms": [
-        "windowsx86-64",
-        "linuxarm64",
-        "linuxx86-64",
-        "linuxathena",
-        "linuxarm32",
-        "osxuniversal"
-      ]
-    }
-  ],
+  "cppDependencies": [],
   "jniDependencies": [],
   "requires": []
 }

--- a/2026/yams-2026.6.21.json
+++ b/2026/yams-2026.6.21.json
@@ -15,25 +15,7 @@
       "version": "2026.6.21"
     }
   ],
-  "cppDependencies": [
-    {
-      "groupId": "yams",
-      "artifactId": "YAMS-cpp",
-      "version": "2026.6.21",
-      "libName": "YAMS",
-      "headerClassifier": "headers",
-      "sharedLibrary": true,
-      "skipInvalidPlatforms": true,
-      "binaryPlatforms": [
-        "windowsx86-64",
-        "linuxarm64",
-        "linuxx86-64",
-        "linuxathena",
-        "linuxarm32",
-        "osxuniversal"
-      ]
-    }
-  ],
+  "cppDependencies": [],
   "jniDependencies": [],
   "requires": []
 }

--- a/2026/yams-2026.7.10.json
+++ b/2026/yams-2026.7.10.json
@@ -15,25 +15,7 @@
       "version": "2026.7.10"
     }
   ],
-  "cppDependencies": [
-    {
-      "groupId": "yams",
-      "artifactId": "YAMS-cpp",
-      "version": "2026.7.10",
-      "libName": "YAMS",
-      "headerClassifier": "headers",
-      "sharedLibrary": true,
-      "skipInvalidPlatforms": true,
-      "binaryPlatforms": [
-        "windowsx86-64",
-        "linuxarm64",
-        "linuxx86-64",
-        "linuxathena",
-        "linuxarm32",
-        "osxuniversal"
-      ]
-    }
-  ],
+  "cppDependencies": [],
   "jniDependencies": [],
   "requires": []
 }


### PR DESCRIPTION
Removed cppDependencies for YAMS-cpp which was unintentionally published.